### PR TITLE
Bug: errors when coercing frozen strings

### DIFF
--- a/lib/coercion.rb
+++ b/lib/coercion.rb
@@ -10,7 +10,7 @@ module Coercion
 
   module StripStrings
     def write_attribute(attr_name, value)
-      value.strip! if value.is_a?(String)
+      value = value.strip if value.is_a?(String)
       super
     end
   end

--- a/lib/coercion.rb
+++ b/lib/coercion.rb
@@ -11,7 +11,7 @@ module Coercion
   module StripStrings
     def write_attribute(attr_name, value)
       value = value.strip if value.is_a?(String)
-      super
+      super(attr_name, value)
     end
   end
 end


### PR DESCRIPTION
Hey Tyler,

I ran into this issue when creating records from XML that I was parsing with Nokogiri. When you select the contents of a node, they're returned to you as a frozen string. I changed the code to use the non-destructive `#strip` instead.
